### PR TITLE
dependency on typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     packages=['subwabbit'],
     install_requires=[
         'mypy-lang',
-        'typing',
+        "typing; python_version < '3.5'",
     ],
     tests_require=[
         'mypy==0.521',

--- a/subwabbit/CHANGELOG.md
+++ b/subwabbit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # subwabbit
 
+## [2.0.1] - 2019-10-17 11:20 - Jan Perich <jan.perich@firma.seznam.cz>
+### Changed
+- conditional dependency on typing package
+
 ## [2.0.0] - 2019-06-14 15:41 - Matej Jakimov <matej.jakimov@gmail.com>
 ### Changed
 - Changed names of formatter methods:


### PR DESCRIPTION
Typing module is part of standard library since python 3.5
Installing typing in newer version of python can cause problems.
https://github.com/python/typing/issues/573