### PR TITLE
Remove obsolete mypy-lang dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
     },
     packages=['subwabbit'],
     install_requires=[
-        'mypy-lang',
         "typing; python_version < '3.5'",
     ],
     tests_require=[

--- a/subwabbit/CHANGELOG.md
+++ b/subwabbit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # subwabbit
 
+## [2.0.2] - 2020-06-18 15:03 - Jan Seifert <jan.seifert@firma.seznam.cz>
+### Fixed
+- remove obsolete `mypy-lang` dependency
+
 ## [2.0.1] - 2019-10-17 11:20 - Jan Perich <jan.perich@firma.seznam.cz>
 ### Changed
 - conditional dependency on typing package


### PR DESCRIPTION
`mypy-lang` is obsolete Python package (last released in 2017) and it is unnecessary run-time dependency. If you have installed `mypy` and then you install the `subwabbit`, after it `mypy` does not work, because `mypy-lang` replaces several MyPy's files .